### PR TITLE
Dirty hack to resolve dependent file needed for multiple runs

### DIFF
--- a/CampaspeModel/GW_link_Integrated/GW_link_Integrated.py
+++ b/CampaspeModel/GW_link_Integrated/GW_link_Integrated.py
@@ -63,7 +63,15 @@ def run(model_folder, data_folder, mf_exe_folder, farm_zones=None, param_file=No
     elif not hasattr(MM, 'ext_linkage_bores') or MM.ext_linkage_bores is None:
 
         # Read in bores that relate to external models
-        model_linking = p_j(data_folder, "model_linking.csv")
+        model_linking = p_j(data_folder, 'model_linking.csv')
+        if not os.path.isfile(model_linking):
+            # assume model run with generated subdirectory
+            model_linking = p_j(data_folder, '..', 'model_linking.csv')
+            if not os.path.isfile(model_linking):
+                raise IOError("Model linkage file could not be found")
+            # End if
+        # End if
+
         with open(model_linking, 'r') as f:
             lines = f.readlines()
 


### PR DESCRIPTION
New approach generates a specific folder for a run as a subdirectory in the given data folder. Look in the given data folder and the parent directory for the model linking file