### PR TITLE
Import initial river levels from npy file instead of pickled file

### DIFF
--- a/CampaspeModel/GW_link_Integrated/GW_link_Integrated.py
+++ b/CampaspeModel/GW_link_Integrated/GW_link_Integrated.py
@@ -380,6 +380,12 @@ def main():
     except (IOError, ImportError):
         fname = "initial_river_levels.npy"
         riv_stages = load_obj(os.path.join(CONFIG.settings['data_folder'], fname))
+    # End try
+
+    if fname.endswith(".pkl"):
+        warnings.warn("Loading of initial river levels from pickled file will be unsupported in the future",
+                      FutureWarning)
+    # End if
 
     args = sys.argv
     if len(args) > 1:

--- a/CampaspeModel/GW_link_Integrated/GW_link_Integrated.py
+++ b/CampaspeModel/GW_link_Integrated/GW_link_Integrated.py
@@ -377,7 +377,7 @@ def main():
     try:
         fname = "initial_river_levels.pkl"
         riv_stages = load_obj(os.path.join(CONFIG.settings['data_folder'], fname))
-    except (IOError):
+    except (IOError, ImportError):
         fname = "initial_river_levels.npy"
         riv_stages = load_obj(os.path.join(CONFIG.settings['data_folder'], fname))
 


### PR DESCRIPTION
Npy is the safer (read 'cross-platform') option here. Attempting to read in a pickle file often results in an ImportError (no module named multiarray)